### PR TITLE
xref-go-{forward,back}

### DIFF
--- a/src/main/kotlin/com/github/strindberg/emacsj/actions/xref/XrefGoBackAction.kt
+++ b/src/main/kotlin/com/github/strindberg/emacsj/actions/xref/XrefGoBackAction.kt
@@ -1,0 +1,13 @@
+package com.github.strindberg.emacsj.actions.xref
+
+import com.github.strindberg.emacsj.xref.Type
+import com.github.strindberg.emacsj.xref.XrefHandler
+import com.intellij.codeInsight.CodeInsightActionHandler
+import com.intellij.codeInsight.actions.BaseCodeInsightAction
+import com.intellij.openapi.project.DumbAware
+
+class XrefGoBackAction : BaseCodeInsightAction(), DumbAware {
+
+    private val actionHandler = XrefHandler(Type.GO_BACK)
+    override fun getHandler(): CodeInsightActionHandler = actionHandler
+}

--- a/src/main/kotlin/com/github/strindberg/emacsj/actions/xref/XrefGoForwardAction.kt
+++ b/src/main/kotlin/com/github/strindberg/emacsj/actions/xref/XrefGoForwardAction.kt
@@ -1,0 +1,13 @@
+package com.github.strindberg.emacsj.actions.xref
+
+import com.github.strindberg.emacsj.xref.Type
+import com.github.strindberg.emacsj.xref.XrefHandler
+import com.intellij.codeInsight.CodeInsightActionHandler
+import com.intellij.codeInsight.navigation.actions.GotoDeclarationAction
+import com.intellij.openapi.project.DumbAware
+
+class XrefGoForwardAction : GotoDeclarationAction(), DumbAware {
+
+    private val actionHandler = XrefHandler(Type.GO_FORWARD)
+    override fun getHandler(): CodeInsightActionHandler = actionHandler
+}

--- a/src/main/kotlin/com/github/strindberg/emacsj/xref/XrefHandler.kt
+++ b/src/main/kotlin/com/github/strindberg/emacsj/xref/XrefHandler.kt
@@ -1,0 +1,41 @@
+package com.github.strindberg.emacsj.xref
+
+import com.github.strindberg.emacsj.mark.LimitedStack
+import com.github.strindberg.emacsj.mark.PlaceInfoWrapper
+import com.intellij.codeInsight.CodeInsightActionHandler
+import com.intellij.codeInsight.navigation.actions.GotoDeclarationOrUsageHandler2
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.editor.ex.EditorEx
+import com.intellij.openapi.fileEditor.ex.IdeDocumentHistory
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiFile
+
+enum class Type { GO_FORWARD, GO_BACK }
+
+class XrefHandler(val type: Type) : CodeInsightActionHandler {
+
+    override fun startInWriteAction(): Boolean = GotoDeclarationOrUsageHandler2.startInWriteAction()
+
+    override fun invoke(project: Project, editor: Editor, file: PsiFile) {
+        (editor as? EditorEx)?.let { editorEx ->
+            when (type) {
+                Type.GO_FORWARD -> {
+                    val cursorPos = PlaceInfoWrapper.placeInfo(editorEx, editorEx.caretModel.offset, file.virtualFile)
+                    if (cursorPos != null && history.peek() != cursorPos) {
+                        history.push(cursorPos)
+                    }
+                    GotoDeclarationOrUsageHandler2.invoke(project, editor, file)
+                }
+                Type.GO_BACK -> {
+                    history.pop()?.let { cursorPos ->
+                        IdeDocumentHistory.getInstance(project).gotoPlaceInfo(cursorPos.placeInfo)
+                    }
+                }
+            }
+        }
+    }
+
+    companion object {
+        private val history: LimitedStack<PlaceInfoWrapper> = LimitedStack()
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -341,6 +341,19 @@ de-activate the ones you don't want to use.</p>
             <keyboard-shortcut first-keystroke="control K" keymap="Emacs"/>
         </action>
 
+        <action id="com.github.strindberg.emacsj.actions.xref.goforward"
+                class="com.github.strindberg.emacsj.actions.xref.XrefGoForwardAction"
+                text="Xref Go Forward">
+            <keyboard-shortcut first-keystroke="alt PERIOD" keymap="$default"/>
+            <keyboard-shortcut first-keystroke="alt PERIOD" keymap="Emacs"/>
+        </action>
+        <action id="com.github.strindberg.emacsj.actions.xref.goback"
+                class="com.github.strindberg.emacsj.actions.xref.XrefGoBackAction"
+                text="Xref Go Back">
+            <keyboard-shortcut first-keystroke="alt COMMA" keymap="$default"/>
+            <keyboard-shortcut first-keystroke="alt COMMA" keymap="Emacs"/>
+        </action>
+
         <action id="com.github.strindberg.emacsj.actions.zap.zapto"
                 class="com.github.strindberg.emacsj.actions.zap.ZapToCharAction"
                 text="Zap To Character">

--- a/src/main/resources/keymaps/EmacsJ.xml
+++ b/src/main/resources/keymaps/EmacsJ.xml
@@ -140,6 +140,12 @@
     <action id="com.github.strindberg.emacsj.actions.kill.kill">
         <keyboard-shortcut first-keystroke="control K"/>
     </action>
+    <action id="com.github.strindberg.emacsj.actions.xref.gotoforward">
+        <keyboard-shortcut first-keystroke="alt PERIOD"/>
+    </action>
+    <action id="com.github.strindberg.emacsj.actions.xref.gotoback">
+        <keyboard-shortcut first-keystroke="alt COMMA"/>
+    </action>
     <action id="com.github.strindberg.emacsj.actions.zap.zapto">
         <keyboard-shortcut first-keystroke="alt Z"/>
     </action>
@@ -195,6 +201,10 @@
     </action>
     <action id="$Paste">
         <keyboard-shortcut first-keystroke="shift INSERT"/>
+    </action>
+    <action id="GotoDeclaration">
+        <keyboard-shortcut first-keystroke="control alt G"/>
+        <keyboard-shortcut first-keystroke="ESCAPE" second-keystroke="PERIOD"/>
     </action>
 
     <!--Conflicting shortcuts from $default.xml removed-->

--- a/src/test/kotlin/com/github/strindberg/emacsj/xref/XrefTest.kt
+++ b/src/test/kotlin/com/github/strindberg/emacsj/xref/XrefTest.kt
@@ -1,0 +1,26 @@
+package com.github.strindberg.emacsj.xref
+
+import com.github.strindberg.emacsj.mark.MarkHandler
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+
+private const val ACTION_XREF_GO_FORWARD = "com.github.strindberg.emacsj.actions.xref.goforward"
+private const val ACTION_XREF_GO_BACK = "com.github.strindberg.emacsj.actions.xref.goback"
+
+class XrefTest : BasePlatformTestCase() {
+
+    fun `test xef Go Forward`() {
+        MarkHandler.editorTypeId = ""
+        myFixture.configureByText("test.java", "class Test {\n public static void foo() {}\n public static void bar() { f<caret>oo() }\n}")
+        myFixture.performEditorAction(ACTION_XREF_GO_FORWARD)
+        myFixture.checkResult("class Test {\n public static void <caret>foo() {}\n public static void bar() { foo() }\n}")
+    }
+
+    fun `test xref Go Back`() {
+        MarkHandler.editorTypeId = ""
+        myFixture.configureByText("test.java", "class Test {\n public static void foo() {}\n public static void bar() { f<caret>oo() }\n}")
+        myFixture.performEditorAction(ACTION_XREF_GO_FORWARD)
+        myFixture.checkResult("class Test {\n public static void <caret>foo() {}\n public static void bar() { foo() }\n}")
+        myFixture.performEditorAction(ACTION_XREF_GO_BACK)
+        myFixture.checkResult("class Test {\n public static void foo() {}\n public static void bar() { f<caret>oo() }\n}")
+    }
+}


### PR DESCRIPTION
This adds xref-go-forward/xref-go-back actions similar to those in Gnu/Emacs, which act as GotoDeclaration, but stores the position when Goto was called and allows to go back to it. The history is global instead of per-project, afaik it's default in Emacs.